### PR TITLE
fix: PostgreSQL 연결 예시 수정

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -7,4 +7,4 @@ DISCORD_CLIENT_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 POSTGRES_PASSWORD=
-DATABASE_URL=postgresql+psycopg://issuebell:CHANGE_ME@postgres:5432/issuebell
+DATABASE_URL=postgresql+psycopg2://issuebell:CHANGE_ME@postgres:5432/issuebell


### PR DESCRIPTION
운영 이미지에 설치된 psycopg2-binary와 일치하도록 DATABASE_URL 예시의 SQLAlchemy 드라이버 이름을 수정합니다.